### PR TITLE
feature/image pixel scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ E.g. this is correct:
 </div>
 ```
 
+-   You must add the following code block to the site head code to prevent a FOUT on page load
+
+```
+<style>
+img[data-module="fancy-image"]{
+    visibility: hidden;
+}
+</style>
+```
+
 **Attributes**
 | name | required? | value | default | description |
 |----------------------- |----------- |-------------------- |----------- |------------------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -117,10 +117,11 @@ img[data-module="fancy-image"]{
 
 **Attributes**
 | name | required? | value | default | description |
-|----------------------- |----------- |-------------------- |----------- |------------------------------------------------------------------------------------- |
+| ---------------------------- | --------- | ------------------ | --------- | ----------------------------------------------------------------------------------- |
 | data-module | yes | "fancy-image" | n/a | Tells our custom code that you want to create a fancy image. |
 | data-object-fit | no | "contain"\|"cover" | "contain" | Tells our custom code what object-fit scaling behavior the fancy image should have. |
 | data-dither-enabled | no | n/a | n/a | Tells our custom code that you want your fancy image to be dithered. |
+| data-pixel-animation-enabled | no | n/a | n/a | Tells our custom code that you want this image to pixel animate in |
 | data-hover | no | n/a | n/a | Enables a hover effect |
 
 ## Pop Quote

--- a/index.html
+++ b/index.html
@@ -43,6 +43,28 @@
                     alt=""
                 />
             </div>
+            <div>
+                <img
+                    style="max-width: 100%"
+                    class="image"
+                    src="/assets/img/Chris.png"
+                    data-object-fit="contain"
+                    data-module="fancy-image"
+                    data-hover
+                    alt=""
+                />
+            </div>
+            <div>
+                <img
+                    style="max-width: 100%"
+                    class="image"
+                    src="/assets/img/Dustin.png"
+                    data-object-fit="contain"
+                    data-module="fancy-image"
+                    data-hover
+                    alt=""
+                />
+            </div>
         </div>
         <!-- <div
             style="height: 75vh; position: relative"

--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
                     data-object-fit="contain"
                     data-module="fancy-image"
                     data-dither-enabled
+                    data-pixel-animation-enabled
                     data-hover
                     alt=""
                 />
@@ -50,6 +51,7 @@
                     src="/assets/img/Chris.png"
                     data-object-fit="contain"
                     data-module="fancy-image"
+                    data-pixel-animation-enabled
                     data-hover
                     alt=""
                 />

--- a/js/App.js
+++ b/js/App.js
@@ -49,6 +49,7 @@ export default class App {
 
     bindListeners() {
         this.time.on("tick", this.update);
+        this.sizes.on("resize", this.resize);
         this.sizes.on("window resize end", this.resizeEnd);
     }
 

--- a/js/App.js
+++ b/js/App.js
@@ -44,7 +44,7 @@ export default class App {
     resize() {}
 
     resizeEnd() {
-        this.fancyImage.resizeEnd();
+        this.fancyImage.resize();
     }
 
     bindListeners() {

--- a/js/modules/FancyImage.js
+++ b/js/modules/FancyImage.js
@@ -21,6 +21,8 @@ class _FancyImage {
     objectFit = "contain";
     // inferred from settings
     scaleFunc = null;
+    // props
+    img = null; // canvas image
 
     constructor(node) {
         this.init(node);
@@ -40,8 +42,8 @@ class _FancyImage {
         // Detect image window size
         const { width, height } = this.DOM.el.getBoundingClientRect();
 
-        // Load new image
-        const img = await imagePromise(this.src);
+        // Clone image to append to DOM
+        const img = this.img.cloneNode(true);
         img.classList.add("fancy-image__img");
 
         // Calculate img and canvas sizing based on object fit mode
@@ -99,6 +101,7 @@ class _FancyImage {
 
         // inferred from settings
         this.scaleFunc = intrinsicScale[this.objectFit];
+        this.img = await imagePromise(this.src);
 
         this.render();
     };

--- a/js/modules/FancyImage.js
+++ b/js/modules/FancyImage.js
@@ -90,7 +90,7 @@ class _FancyImage {
         this.DOM.container.classList.add("fancy-image--ready");
     };
 
-    drawImage = () => {
+    drawFirstFrame = () => {
         // Dither the image
         if (this.ditherEnabled) {
             // Create image buf to render into canvas
@@ -155,7 +155,7 @@ class _FancyImage {
         this.ctx.clearRect(0, 0, this.scaled.width, this.scaled.height);
 
         // Draw the first frame
-        this.drawImage();
+        this.drawFirstFrame();
 
         // Draw the original image at a fraction of the final size
         this.ctx.drawImage(this.DOM.canvas, 0, 0, w * size, h * size);
@@ -228,7 +228,7 @@ class _FancyImage {
         this.setCanvas();
 
         this.setMediaSizes();
-        this.drawImage();
+        this.drawFirstFrame();
 
         this.animatePixels();
     };

--- a/js/modules/FancyImage.js
+++ b/js/modules/FancyImage.js
@@ -37,7 +37,7 @@ class _FancyImage {
         this.render();
     }
 
-    resizeEnd = () => {
+    resize = () => {
         this.DOM.container.classList.remove("fancy-image--ready");
         this.DOM.container.innerHTML = "";
         this.render();
@@ -103,10 +103,10 @@ export default class FancyImage {
         this.$targets = this.app.core.dom.fancyImage;
     }
 
-    resizeEnd = () => {
+    resize = () => {
         if (this.instances.length <= 0) return;
         this.instances.forEach((instance) => {
-            instance.resizeEnd();
+            instance.resize();
         });
     };
 

--- a/js/modules/FancyImage.js
+++ b/js/modules/FancyImage.js
@@ -26,6 +26,7 @@ class _FancyImage {
     scaleFunc = null;
     // props
     scaled = {}; // holds scaled positioning values
+    imgRatio = null; // the image's aspect ratio
     ctx = null; // canvas context
 
     constructor(node) {
@@ -89,6 +90,15 @@ class _FancyImage {
                 this.scaled.height,
             );
             ditherWith(ATKINSON, buf).blitCanvas(this.DOM.canvas);
+        } else {
+            // Draw the initial image
+            this.ctx.drawImage(
+                this.DOM.img,
+                0,
+                0,
+                this.scaled.width,
+                this.scaled.height,
+            );
         }
     };
 
@@ -118,6 +128,7 @@ class _FancyImage {
         this.DOM.img = await imagePromise(this.src);
         this.DOM.img.classList.add("fancy-image__img");
         this.DOM.inner.appendChild(this.DOM.img);
+        this.imgRatio = this.DOM.img.naturalWidth / this.DOM.img.naturalHeight;
 
         this.setScaled();
         this.setCanvas();

--- a/js/modules/FancyImage.js
+++ b/js/modules/FancyImage.js
@@ -20,21 +20,7 @@ class _FancyImage {
     objectFit = "contain";
 
     constructor(node) {
-        // setup
-        this.DOM.el = node;
-        this.DOM.parentEl = this.DOM.el.parentElement;
-        this.DOM.parentEl.dataset.fancyImageParent = ""; // add parent positioning attribute
-        this.DOM.container = document.createElement("div");
-        this.DOM.container.classList.add("fancy-image");
-        this.DOM.parentEl.appendChild(this.DOM.container); // app as next sibling of source node
-
-        // settings from node
-        this.src = this.DOM.el.src;
-        this.objectFit = this.DOM.el.dataset.objectFit ?? "contain"; // object fit mode
-        this.ditherEnabled =
-            typeof this.DOM.el.dataset.ditherEnabled !== "undefined" ?? false;
-
-        this.render();
+        this.init(node);
     }
 
     resize = () => {
@@ -91,6 +77,24 @@ class _FancyImage {
         inner.appendChild(canvas);
         this.DOM.container.appendChild(inner);
         this.DOM.container.classList.add("fancy-image--ready");
+    };
+
+    init = async (node) => {
+        // setup
+        this.DOM.el = node;
+        this.DOM.parentEl = this.DOM.el.parentElement;
+        this.DOM.parentEl.dataset.fancyImageParent = ""; // add parent positioning attribute
+        this.DOM.container = document.createElement("div");
+        this.DOM.container.classList.add("fancy-image");
+        this.DOM.parentEl.appendChild(this.DOM.container); // app as next sibling of source node
+
+        // settings from node
+        this.src = this.DOM.el.src;
+        this.objectFit = this.DOM.el.dataset.objectFit ?? "contain"; // object fit mode
+        this.ditherEnabled =
+            typeof this.DOM.el.dataset.ditherEnabled !== "undefined" ?? false;
+
+        this.render();
     };
 }
 

--- a/js/modules/FancyImage.js
+++ b/js/modules/FancyImage.js
@@ -15,9 +15,12 @@ class _FancyImage {
         parentEl: null,
         container: null,
     };
+    // settings
     src = null;
     ditherEnabled = false;
     objectFit = "contain";
+    // inferred from settings
+    scaleFunc = null;
 
     constructor(node) {
         this.init(node);
@@ -42,7 +45,7 @@ class _FancyImage {
         img.classList.add("fancy-image__img");
 
         // Calculate img and canvas sizing based on object fit mode
-        const scaled = intrinsicScale[this.objectFit](
+        const scaled = this.scaleFunc(
             width,
             height,
             img.naturalWidth,
@@ -93,6 +96,9 @@ class _FancyImage {
         this.objectFit = this.DOM.el.dataset.objectFit ?? "contain"; // object fit mode
         this.ditherEnabled =
             typeof this.DOM.el.dataset.ditherEnabled !== "undefined" ?? false;
+
+        // inferred from settings
+        this.scaleFunc = intrinsicScale[this.objectFit];
 
         this.render();
     };

--- a/js/modules/FancyImage.js
+++ b/js/modules/FancyImage.js
@@ -21,6 +21,7 @@ class _FancyImage {
     // settings
     src = null;
     ditherEnabled = false;
+    pixelAnimationEnabled = false;
     objectFit = "contain";
     // inferred from settings
     scaleFunc = null;
@@ -86,8 +87,6 @@ class _FancyImage {
         this.DOM.canvas.style.height = `${this.scaled.height}px`;
         this.DOM.canvas.style.top = `${this.scaled.y}px`;
         this.DOM.canvas.style.left = `${this.scaled.x}px`;
-
-        this.DOM.container.classList.add("fancy-image--ready");
     };
 
     drawFinalFrame = () => {
@@ -154,7 +153,7 @@ class _FancyImage {
         // Clear the canvas
         this.ctx.clearRect(0, 0, this.scaled.width, this.scaled.height);
 
-        // Draw the first frame
+        // Draw the final frame
         this.drawFinalFrame();
 
         // Draw the original image at a fraction of the final size
@@ -179,19 +178,20 @@ class _FancyImage {
      * Renders the image with increasing pixelation factor at each step.
      */
     animatePixels = () => {
-        console.log("here");
         if (this.pxIndex < this.pxFactorValues.length) {
             // Increase the pixelation factor and continue animating
             setTimeout(
                 () => {
                     // Render the image with the current pixelation factor
                     this.renderPixelFrame();
+                    this.DOM.container.classList.add("fancy-image--ready");
                     this.pxIndex++;
                     this.animatePixels();
                 },
                 this.pxIndex === 0 ? 300 : 80,
             ); // The first time should be the longest.
         } else {
+            this.DOM.container.classList.add("fancy-image--animate-end");
             this.pxIndex = this.pxFactorValues.length - 1;
         }
     };
@@ -205,6 +205,9 @@ class _FancyImage {
         this.objectFit = this.DOM.el.dataset.objectFit ?? "contain"; // object fit mode
         this.ditherEnabled =
             typeof this.DOM.el.dataset.ditherEnabled !== "undefined" ?? false;
+        this.pixelAnimationEnabled =
+            typeof this.DOM.el.dataset.pixelAnimationEnabled !== "undefined" ??
+            false;
         this.scaleFunc = intrinsicScale[this.objectFit];
 
         // DOM
@@ -230,7 +233,11 @@ class _FancyImage {
         this.setMediaSizes();
         this.drawFinalFrame();
 
-        this.animatePixels();
+        if (this.pixelAnimationEnabled) {
+            this.animatePixels();
+        } else {
+            this.DOM.container.classList.add("fancy-image--ready");
+        }
     };
 }
 

--- a/js/modules/FancyImage.js
+++ b/js/modules/FancyImage.js
@@ -34,7 +34,7 @@ class _FancyImage {
 
     resize = () => {
         this.setScaled();
-        this.render();
+        this.setMediaSizes();
         this.drawImage();
     };
 
@@ -62,7 +62,7 @@ class _FancyImage {
         this.ctx = ctx;
     };
 
-    render = async () => {
+    setMediaSizes = async () => {
         // Apply object fit styles
         this.DOM.img.style.width = `${this.scaled.width}px`;
         this.DOM.img.style.height = `${this.scaled.height}px`;
@@ -122,7 +122,7 @@ class _FancyImage {
         this.setScaled();
         this.setCanvas();
 
-        this.render();
+        this.setMediaSizes();
         this.drawImage();
     };
 }

--- a/js/modules/FancyImage.js
+++ b/js/modules/FancyImage.js
@@ -35,7 +35,7 @@ class _FancyImage {
     // visible for a longer time.
     // Towards the end we don't add many values as
     // we want the sharpening up to happen quickly here.
-    pxFactorValues = [1, 2, 4, 9, 100];
+    pxFactorValues = [2, 4, 9, 50, 100];
     pxIndex = 0;
     // the dithered image IntBuffer for rendering to canvas
     ditheredBuf = null;
@@ -90,7 +90,7 @@ class _FancyImage {
         this.DOM.container.classList.add("fancy-image--ready");
     };
 
-    drawFirstFrame = () => {
+    drawFinalFrame = () => {
         // Dither the image
         if (this.ditherEnabled) {
             // Create image buf to render into canvas
@@ -155,7 +155,7 @@ class _FancyImage {
         this.ctx.clearRect(0, 0, this.scaled.width, this.scaled.height);
 
         // Draw the first frame
-        this.drawFirstFrame();
+        this.drawFinalFrame();
 
         // Draw the original image at a fraction of the final size
         this.ctx.drawImage(this.DOM.canvas, 0, 0, w * size, h * size);
@@ -228,7 +228,7 @@ class _FancyImage {
         this.setCanvas();
 
         this.setMediaSizes();
-        this.drawFirstFrame();
+        this.drawFinalFrame();
 
         this.animatePixels();
     };

--- a/styles/modules/fancyImage.scss
+++ b/styles/modules/fancyImage.scss
@@ -2,11 +2,12 @@
     position: relative;
 }
 
-img[data-module="fancy-image"] {
+[data-module="fancy-image"] {
+    // hide source image
     visibility: hidden;
 }
 
-img[data-module="fancy-image"] + .fancy-image {
+[data-module="fancy-image"] + .fancy-image {
     position: absolute;
     top: 0;
     left: 0;
@@ -15,8 +16,8 @@ img[data-module="fancy-image"] + .fancy-image {
     visibility: hidden;
     opacity: 0;
     transition:
-        visibility 200ms ease-in-out,
-        opacity 200ms ease-in-out;
+        visibility 100ms ease-in-out,
+        opacity 200ms 100ms ease-in-out;
 
     .fancy-image__inner {
         position: relative;
@@ -47,14 +48,27 @@ img[data-module="fancy-image"] + .fancy-image {
     &.fancy-image--ready {
         visibility: visible;
         opacity: 1;
+    }
+}
 
-        canvas.fancy-image__canvas {
-            opacity: 1;
-            filter: blur(0px);
-            transition:
-                opacity 200ms linear,
-                filter 300ms linear;
-        }
+[data-module="fancy-image"][data-pixel-animation-enabled]:not(
+        [data-dither-enabled]
+    )
+    + .fancy-image.fancy-image--animate-end {
+    canvas.fancy-image__canvas {
+        transition: opacity 100ms linear;
+        opacity: 0;
+    }
+}
+
+// Hover styles
+[data-module="fancy-image"][data-hover] + .fancy-image {
+    canvas.fancy-image__canvas {
+        opacity: 1;
+        filter: blur(0px);
+        transition:
+            opacity 200ms linear,
+            filter 300ms linear;
     }
 }
 
@@ -65,5 +79,16 @@ img[data-module="fancy-image"] + .fancy-image {
         transition:
             filter 200ms linear,
             opacity 300ms linear;
+    }
+}
+
+// overrides
+// fallback to original image if no effects are enabled
+[data-module="fancy-image"]:not([data-dither-enabled]):not(
+        [data-pixel-animation-enabled]
+    ) {
+    visibility: visible;
+    + .fancy-image {
+        visibility: hidden;
     }
 }

--- a/styles/modules/fancyImage.scss
+++ b/styles/modules/fancyImage.scss
@@ -2,7 +2,11 @@
     position: relative;
 }
 
-[data-module="fancy-image"] + .fancy-image {
+img[data-module="fancy-image"] {
+    visibility: hidden;
+}
+
+img[data-module="fancy-image"] + .fancy-image {
     position: absolute;
     top: 0;
     left: 0;


### PR DESCRIPTION
- Make each image a class instance
- Tweak resize naming
- Wire in global resize handler
- Setup async init
- Setup scale func
- Store img on instance
- Refactor instance to improve resize performance
- Better naming for media sizing func
- Setup drawing bare image when dither is disabled
- Setup pixel animate in effect
- Better name for first frame draw func
- Improve naming
- Hide source image
- Improve styles for smoother load animations
- Update readme with style instructions
- Update docs with pixel animation attribute
