### PR TITLE
enhancement/3d opacity

### DIFF
--- a/js/components/3D/Common/Outlines.jsx
+++ b/js/components/3D/Common/Outlines.jsx
@@ -3,7 +3,7 @@ import { useControls } from "leva";
 
 import * as colors from "@/js/core/colors";
 
-export default function Outlines({ children }) {
+export default function Outlines({ children, opacity = 1 }) {
     const { outlineThickness, outlineColor } = useControls("Outlines", {
         outlineColor: {
             value: colors.black,
@@ -16,7 +16,12 @@ export default function Outlines({ children }) {
         },
     });
     return (
-        <_Outlines thickness={outlineThickness} color={outlineColor}>
+        <_Outlines
+            thickness={outlineThickness}
+            color={outlineColor}
+            transparent
+            opacity={opacity}
+        >
             {children}
         </_Outlines>
     );

--- a/js/components/3D/Materials/index.jsx
+++ b/js/components/3D/Materials/index.jsx
@@ -4,7 +4,7 @@ import { useRef } from "react";
 
 import * as colors from "@/js/core/colors";
 
-export const GrainMaterialRed = ({ boundingBox }) => {
+export const GrainMaterialRed = ({ boundingBox, opacity = 1 }) => {
     const shaderRef = useRef();
     const {
         uNoiseScale,
@@ -94,12 +94,14 @@ export const GrainMaterialRed = ({ boundingBox }) => {
             uMatcapEnabled={uMatcapEnabled}
             uNoiseEnabled={uNoiseEnabled}
             uGradientEnabled={uGradientEnabled}
+            opacity={opacity}
+            transparent
             ref={shaderRef}
         />
     );
 };
 
-export const GrainMaterialRedDark = ({ boundingBox }) => {
+export const GrainMaterialRedDark = ({ boundingBox, opacity = 1 }) => {
     const shaderRef = useRef();
     const {
         uNoiseScale,
@@ -189,11 +191,13 @@ export const GrainMaterialRedDark = ({ boundingBox }) => {
             uMatcapEnabled={uMatcapEnabled}
             uNoiseEnabled={uNoiseEnabled}
             uGradientEnabled={uGradientEnabled}
+            opacity={opacity}
+            transparent
             ref={shaderRef}
         />
     );
 };
-export const GrainMaterialYellow = ({ boundingBox }) => {
+export const GrainMaterialYellow = ({ boundingBox, opacity = 1 }) => {
     const shaderRef = useRef();
     const {
         uNoiseScale,
@@ -283,12 +287,14 @@ export const GrainMaterialYellow = ({ boundingBox }) => {
             uMatcapEnabled={uMatcapEnabled}
             uNoiseEnabled={uNoiseEnabled}
             uGradientEnabled={uGradientEnabled}
+            opacity={opacity}
+            transparent
             ref={shaderRef}
         />
     );
 };
 
-export const GrainMaterialYellowDark = ({ boundingBox }) => {
+export const GrainMaterialYellowDark = ({ boundingBox, opacity = 1 }) => {
     const shaderRef = useRef();
     const {
         uNoiseScale,
@@ -378,11 +384,13 @@ export const GrainMaterialYellowDark = ({ boundingBox }) => {
             uMatcapEnabled={uMatcapEnabled}
             uNoiseEnabled={uNoiseEnabled}
             uGradientEnabled={uGradientEnabled}
+            opacity={opacity}
+            transparent
             ref={shaderRef}
         />
     );
 };
-export const GrainMaterialViolet = ({ boundingBox }) => {
+export const GrainMaterialViolet = ({ boundingBox, opacity = 1 }) => {
     const shaderRef = useRef();
     const {
         uNoiseScale,
@@ -472,12 +480,14 @@ export const GrainMaterialViolet = ({ boundingBox }) => {
             uMatcapEnabled={uMatcapEnabled}
             uNoiseEnabled={uNoiseEnabled}
             uGradientEnabled={uGradientEnabled}
+            opacity={opacity}
+            transparent
             ref={shaderRef}
         />
     );
 };
 
-export const GrainMaterialVioletDark = ({ boundingBox }) => {
+export const GrainMaterialVioletDark = ({ boundingBox, opacity = 1 }) => {
     const shaderRef = useRef();
     const {
         uNoiseScale,
@@ -567,11 +577,15 @@ export const GrainMaterialVioletDark = ({ boundingBox }) => {
             uMatcapEnabled={uMatcapEnabled}
             uNoiseEnabled={uNoiseEnabled}
             uGradientEnabled={uGradientEnabled}
+            opacity={opacity}
+            transparent
             ref={shaderRef}
         />
     );
 };
 
-export const OutlineMaterial = () => {
-    return <meshBasicMaterial color={colors.black} />;
+export const OutlineMaterial = ({ opacity = 1 }) => {
+    return (
+        <meshBasicMaterial color={colors.black} transparent opacity={opacity} />
+    );
 };

--- a/js/components/3D/Models/CareersModel.jsx
+++ b/js/components/3D/Models/CareersModel.jsx
@@ -13,7 +13,7 @@ import {
     GrainMaterialYellowDark,
 } from "@/js/components/3D/Materials";
 
-export default function CareersModel(props) {
+export default function CareersModel({ opacity = 1, ...props }) {
     const [boundingBox, setBoundingBox] = useState({
         min: new THREE.Vector3(0, 0, 0),
         max: new THREE.Vector3(1, 1, 1),
@@ -68,8 +68,11 @@ export default function CareersModel(props) {
                             //   material={materials.green_01}
                             position={[0.033, -0.017, 0.017]}
                         >
-                            <GrainMaterialYellow boundingBox={boundingBox} />
-                            <Outlines />
+                            <GrainMaterialYellow
+                                boundingBox={boundingBox}
+                                opacity={opacity}
+                            />
+                            <Outlines opacity={opacity} />
                             <mesh
                                 name="fluid"
                                 geometry={nodes.fluid.geometry}
@@ -79,8 +82,9 @@ export default function CareersModel(props) {
                             >
                                 <GrainMaterialYellowDark
                                     boundingBox={boundingBox}
+                                    opacity={opacity}
                                 />
-                                <Outlines />
+                                <Outlines opacity={opacity} />
                             </mesh>
                         </mesh>
                     </group>

--- a/js/components/3D/Models/CdmModel.jsx
+++ b/js/components/3D/Models/CdmModel.jsx
@@ -13,7 +13,7 @@ import {
     OutlineMaterial,
 } from "@/js/components/3D/Materials";
 
-export default function CdmModel(props) {
+export default function CdmModel({ opacity = 1, ...props }) {
     const [mounted, setMounted] = useState(false);
     const [boundingBox, setBoundingBox] = useState({
         min: new THREE.Vector3(0, 0, 0),
@@ -72,7 +72,10 @@ export default function CdmModel(props) {
                             //   material={materials.green_01}
                             position={[-0.003, -0.265, -0.005]}
                         >
-                            <GrainMaterialYellow boundingBox={boundingBox} />
+                            <GrainMaterialYellow
+                                opacity={opacity}
+                                boundingBox={boundingBox}
+                            />
                             <mesh
                                 name="joystick"
                                 castShadow
@@ -82,6 +85,7 @@ export default function CdmModel(props) {
                                 position={[0, 0.075, 0.02]}
                             >
                                 <GrainMaterialYellow
+                                    opacity={opacity}
                                     boundingBox={boundingBox}
                                 />
                             </mesh>
@@ -93,7 +97,7 @@ export default function CdmModel(props) {
                                 // material={materials.outline}
                                 position={[0, 0.075, 0.02]}
                             >
-                                <OutlineMaterial />
+                                <OutlineMaterial opacity={opacity} />
                             </mesh>
                         </mesh>
                         <mesh
@@ -102,7 +106,7 @@ export default function CdmModel(props) {
                             //   material={materials.outline}
                             position={[-0.003, -0.265, -0.005]}
                         >
-                            <OutlineMaterial />
+                            <OutlineMaterial opacity={opacity} />
                         </mesh>
                         <mesh
                             name="gasket"
@@ -117,6 +121,7 @@ export default function CdmModel(props) {
                             position={[-0.003, -0.265, -0.005]}
                         >
                             <GrainMaterialYellowDark
+                                opacity={opacity}
                                 boundingBox={boundingBox}
                             />
                         </mesh>
@@ -132,7 +137,7 @@ export default function CdmModel(props) {
                             }
                             position={[-0.003, -0.265, -0.005]}
                         >
-                            <OutlineMaterial />
+                            <OutlineMaterial opacity={opacity} />
                         </mesh>
                     </group>
                 </group>

--- a/js/components/3D/Models/ContactModel.jsx
+++ b/js/components/3D/Models/ContactModel.jsx
@@ -13,7 +13,7 @@ import {
 } from "@/js/components/3D/Materials";
 import { Outlines } from "../Common";
 
-export default function ContactModel(props) {
+export default function ContactModel({ opacity = 1, ...props }) {
     const [mounted, setMounted] = useState(false);
     const [boundingBox, setBoundingBox] = useState({
         min: new THREE.Vector3(0, 0, 0),
@@ -87,7 +87,10 @@ export default function ContactModel(props) {
                             position={[0.001, 0.059, 0.028]}
                             rotation={[-0.204, 0, 0]}
                         >
-                            <GrainMaterialYellow boundingBox={boundingBox} />
+                            <GrainMaterialYellow
+                                opacity={opacity}
+                                boundingBox={boundingBox}
+                            />
                             {/* <Outlines /> */}
                             <mesh
                                 name="thruster_01"
@@ -96,9 +99,10 @@ export default function ContactModel(props) {
                                 position={[0.19, -0.367, 0.002]}
                             >
                                 <GrainMaterialYellowDark
+                                    opacity={opacity}
                                     boundingBox={boundingBox}
                                 />
-                                <Outlines />
+                                <Outlines opacity={opacity} />
                             </mesh>
                             <mesh
                                 name="thruster_02"
@@ -108,9 +112,10 @@ export default function ContactModel(props) {
                                 rotation={[0, Math.PI / 4, 0]}
                             >
                                 <GrainMaterialYellowDark
+                                    opacity={opacity}
                                     boundingBox={boundingBox}
                                 />
-                                <Outlines />
+                                <Outlines opacity={opacity} />
                             </mesh>
                             <mesh
                                 name="thruster_03"
@@ -120,9 +125,10 @@ export default function ContactModel(props) {
                                 rotation={[0, Math.PI / 2, 0]}
                             >
                                 <GrainMaterialYellowDark
+                                    opacity={opacity}
                                     boundingBox={boundingBox}
                                 />
-                                <Outlines />
+                                <Outlines opacity={opacity} />
                             </mesh>
                             <mesh
                                 name="thruster_04"
@@ -132,9 +138,10 @@ export default function ContactModel(props) {
                                 rotation={[-Math.PI, Math.PI / 4, -Math.PI]}
                             >
                                 <GrainMaterialYellowDark
+                                    opacity={opacity}
                                     boundingBox={boundingBox}
                                 />
-                                <Outlines />
+                                <Outlines opacity={opacity} />
                             </mesh>
                             <mesh
                                 name="thruster_05"
@@ -144,9 +151,10 @@ export default function ContactModel(props) {
                                 rotation={[Math.PI, 0, Math.PI]}
                             >
                                 <GrainMaterialYellowDark
+                                    opacity={opacity}
                                     boundingBox={boundingBox}
                                 />
-                                <Outlines />
+                                <Outlines opacity={opacity} />
                             </mesh>
                             <mesh
                                 name="thruster_06"
@@ -156,9 +164,10 @@ export default function ContactModel(props) {
                                 rotation={[Math.PI, -Math.PI / 4, Math.PI]}
                             >
                                 <GrainMaterialYellowDark
+                                    opacity={opacity}
                                     boundingBox={boundingBox}
                                 />
-                                <Outlines />
+                                <Outlines opacity={opacity} />
                             </mesh>
                             <mesh
                                 name="thruster_07"
@@ -168,9 +177,10 @@ export default function ContactModel(props) {
                                 rotation={[0, -1.571, 0]}
                             >
                                 <GrainMaterialYellowDark
+                                    opacity={opacity}
                                     boundingBox={boundingBox}
                                 />
-                                <Outlines />
+                                <Outlines opacity={opacity} />
                             </mesh>
                             <mesh
                                 name="thruster_08"
@@ -180,9 +190,10 @@ export default function ContactModel(props) {
                                 rotation={[0, -Math.PI / 4, 0]}
                             >
                                 <GrainMaterialYellowDark
+                                    opacity={opacity}
                                     boundingBox={boundingBox}
                                 />
-                                <Outlines />
+                                <Outlines opacity={opacity} />
                             </mesh>
                             <mesh
                                 name="windows"
@@ -196,6 +207,7 @@ export default function ContactModel(props) {
                                 }
                             >
                                 <GrainMaterialYellowDark
+                                    opacity={opacity}
                                     boundingBox={boundingBox}
                                 />
                                 {/* <Outlines /> */}

--- a/js/components/3D/Models/CultureModel.jsx
+++ b/js/components/3D/Models/CultureModel.jsx
@@ -79,7 +79,10 @@ export default function Model({ opacity = 1, ...props }) {
                             position={[0.033, -0.076, -0.111]}
                             rotation={[0, -Math.PI / 9, 0]}
                         >
-                            <GrainMaterialYellow boundingBox={boundingBox} />
+                            <GrainMaterialYellow
+                                opacity={opacity}
+                                boundingBox={boundingBox}
+                            />
                         </mesh>
                         <mesh
                             name="camera_outline"

--- a/js/components/3D/Models/CultureModel.jsx
+++ b/js/components/3D/Models/CultureModel.jsx
@@ -13,7 +13,7 @@ import {
     OutlineMaterial,
 } from "../Materials";
 
-export default function Model(props) {
+export default function Model({ opacity = 1, ...props }) {
     const [mounted, setMounted] = useState(true);
     const [boundingBox, setBoundingBox] = useState({
         min: new THREE.Vector3(0, 0, 0),
@@ -94,7 +94,7 @@ export default function Model(props) {
                             position={[0.033, -0.076, -0.111]}
                             rotation={[0, -Math.PI / 9, 0]}
                         >
-                            <OutlineMaterial />
+                            <OutlineMaterial opacity={opacity} />
                         </mesh>
                         <mesh
                             name="frame"
@@ -110,6 +110,7 @@ export default function Model(props) {
                             rotation={[0, -Math.PI / 9, 0]}
                         >
                             <GrainMaterialYellowDark
+                                opacity={opacity}
                                 boundingBox={boundingBox}
                             />
                         </mesh>
@@ -126,7 +127,7 @@ export default function Model(props) {
                             position={[0.033, -0.076, -0.111]}
                             rotation={[0, -Math.PI / 9, 0]}
                         >
-                            <OutlineMaterial />
+                            <OutlineMaterial opacity={opacity} />
                         </mesh>
                     </group>
                 </group>

--- a/js/components/3D/Models/EpbModel.jsx
+++ b/js/components/3D/Models/EpbModel.jsx
@@ -9,7 +9,7 @@ import * as THREE from "three";
 import { GLB_ASSET_URLS } from "@/js/core/constants";
 import { GrainMaterialRed, OutlineMaterial } from "../Materials";
 
-export default function EpbModel(props) {
+export default function EpbModel({ opacity = 1, ...props }) {
     const [mounted, setMounted] = useState(false);
     const [boundingBox, setBoundingBox] = useState({
         min: new THREE.Vector3(0, 0, 0),
@@ -70,7 +70,10 @@ export default function EpbModel(props) {
                             }
                             position={[-0.024, 0.093, 0.006]}
                         >
-                            <GrainMaterialRed boundingBox={boundingBox} />
+                            <GrainMaterialRed
+                                opacity={opacity}
+                                boundingBox={boundingBox}
+                            />
                         </mesh>
                         <mesh
                             name="bolt_outline"
@@ -84,7 +87,7 @@ export default function EpbModel(props) {
                             }
                             position={[-0.024, 0.093, 0.006]}
                         >
-                            <OutlineMaterial />
+                            <OutlineMaterial opacity={opacity} />
                         </mesh>
                     </group>
                 </group>

--- a/js/components/3D/Models/EyeModel.jsx
+++ b/js/components/3D/Models/EyeModel.jsx
@@ -9,7 +9,7 @@ import * as THREE from "three";
 import { GLB_ASSET_URLS } from "@/js/core/constants";
 import { GrainMaterialViolet, OutlineMaterial } from "../Materials";
 
-export default function EyeModel(props) {
+export default function EyeModel({ opacity = 1, ...props }) {
     const [mounted, setMounted] = useState(false);
     const [boundingBox, setBoundingBox] = useState({
         min: new THREE.Vector3(0, 0, 0),
@@ -64,14 +64,17 @@ export default function EyeModel(props) {
                                 nodes.eye001.morphTargetInfluences
                             }
                         >
-                            <GrainMaterialViolet boundingBox={boundingBox} />
+                            <GrainMaterialViolet
+                                opacity={opacity}
+                                boundingBox={boundingBox}
+                            />
                         </mesh>
                         <mesh
                             name="eye_outline"
                             geometry={nodes.eye_outline.geometry}
                             //   material={materials.outline}
                         >
-                            <OutlineMaterial />
+                            <OutlineMaterial opacity={opacity} />
                         </mesh>
                     </group>
                 </group>

--- a/js/components/3D/Models/GyroModel.jsx
+++ b/js/components/3D/Models/GyroModel.jsx
@@ -10,7 +10,7 @@ import { GLB_ASSET_URLS } from "@/js/core/constants";
 import { GrainMaterialViolet, GrainMaterialVioletDark } from "../Materials";
 import { Outlines } from "../Common";
 
-export default function GyroModel(props) {
+export default function GyroModel({ opacity = 1, ...props }) {
     const [mounted, setMounted] = useState(false);
     const [boundingBox, setBoundingBox] = useState({
         min: new THREE.Vector3(0, 0, 0),
@@ -67,8 +67,11 @@ export default function GyroModel(props) {
                             position={[0, -0.657, 0.001]}
                             rotation={[0.028, -0.08, -0.015]}
                         >
-                            <GrainMaterialViolet boundingBox={boundingBox} />
-                            <Outlines />
+                            <GrainMaterialViolet
+                                opacity={opacity}
+                                boundingBox={boundingBox}
+                            />
+                            <Outlines opacity={opacity} />
                             <mesh
                                 name="axis"
                                 castShadow
@@ -79,9 +82,10 @@ export default function GyroModel(props) {
                                 rotation={[0, -0.585, 0]}
                             >
                                 <GrainMaterialVioletDark
+                                    opacity={opacity}
                                     boundingBox={boundingBox}
                                 />
-                                <Outlines />
+                                <Outlines opacity={opacity} />
                             </mesh>
                         </mesh>
                     </group>

--- a/js/components/3D/Models/KeyModel.jsx
+++ b/js/components/3D/Models/KeyModel.jsx
@@ -10,7 +10,7 @@ import { GLB_ASSET_URLS } from "@/js/core/constants";
 import { Outlines } from "../Common";
 import { GrainMaterialViolet } from "../Materials";
 
-export default function KeyModel(props) {
+export default function KeyModel({ opacity = 1, ...props }) {
     const [mounted, setMounted] = useState(false);
     const [boundingBox, setBoundingBox] = useState({
         min: new THREE.Vector3(0, 0, 0),
@@ -73,8 +73,11 @@ export default function KeyModel(props) {
                             // material={materials.green_01}
                             position={[-0.156, -0.34, 0.002]}
                         >
-                            <GrainMaterialViolet boundingBox={boundingBox} />
-                            <Outlines />
+                            <GrainMaterialViolet
+                                opacity={opacity}
+                                boundingBox={boundingBox}
+                            />
+                            <Outlines opacity={opacity} />
                         </mesh>
                         <mesh
                             name="key002"
@@ -82,8 +85,11 @@ export default function KeyModel(props) {
                             // material={nodes.key002.material}
                             position={[0.201, 0.316, 0.003]}
                         >
-                            <GrainMaterialViolet boundingBox={boundingBox} />
-                            <Outlines />
+                            <GrainMaterialViolet
+                                opacity={opacity}
+                                boundingBox={boundingBox}
+                            />
+                            <Outlines opacity={opacity} />
                         </mesh>
                         <mesh
                             name="key003"
@@ -91,8 +97,11 @@ export default function KeyModel(props) {
                             // material={nodes.key003.material}
                             position={[-0.353, -0.308, 0.002]}
                         >
-                            <GrainMaterialViolet boundingBox={boundingBox} />
-                            <Outlines />
+                            <GrainMaterialViolet
+                                opacity={opacity}
+                                boundingBox={boundingBox}
+                            />
+                            <Outlines opacity={opacity} />
                         </mesh>
                         <mesh
                             name="key004"
@@ -100,8 +109,11 @@ export default function KeyModel(props) {
                             // material={nodes.key004.material}
                             position={[0.357, 0.274, 0.006]}
                         >
-                            <GrainMaterialViolet boundingBox={boundingBox} />
-                            <Outlines />
+                            <GrainMaterialViolet
+                                opacity={opacity}
+                                boundingBox={boundingBox}
+                            />
+                            <Outlines opacity={opacity} />
                         </mesh>
                         <mesh
                             name="key005"
@@ -109,8 +121,11 @@ export default function KeyModel(props) {
                             material={nodes.key005.material}
                             position={[0.472, 0.336, 0.007]}
                         >
-                            <GrainMaterialViolet boundingBox={boundingBox} />
-                            <Outlines />
+                            <GrainMaterialViolet
+                                opacity={opacity}
+                                boundingBox={boundingBox}
+                            />
+                            <Outlines opacity={opacity} />
                         </mesh>
                         <mesh
                             name="key006"
@@ -118,8 +133,11 @@ export default function KeyModel(props) {
                             // material={nodes.key006.material}
                             position={[-0.34, -0.517, 0.002]}
                         >
-                            <GrainMaterialViolet boundingBox={boundingBox} />
-                            <Outlines />
+                            <GrainMaterialViolet
+                                opacity={opacity}
+                                boundingBox={boundingBox}
+                            />
+                            <Outlines opacity={opacity} />
                         </mesh>
                     </group>
                 </group>

--- a/js/components/3D/Models/MethodsModel.jsx
+++ b/js/components/3D/Models/MethodsModel.jsx
@@ -10,7 +10,7 @@ import { GLB_ASSET_URLS } from "@/js/core/constants";
 import { Outlines } from "../Common";
 import { GrainMaterialYellow, GrainMaterialYellowDark } from "../Materials";
 
-export default function MethodsModel(props) {
+export default function MethodsModel({ opacity = 1, ...props }) {
     const [mounted, setMounted] = useState(false);
     const [boundingBox, setBoundingBox] = useState({
         min: new THREE.Vector3(0, 0, 0),
@@ -71,9 +71,10 @@ export default function MethodsModel(props) {
                                 // material={materials.green_02}
                             >
                                 <GrainMaterialYellowDark
+                                    opacity={opacity}
                                     boundingBox={boundingBox}
                                 />
-                                <Outlines />
+                                <Outlines opacity={opacity} />
                             </mesh>
                             <mesh
                                 name="Cylinder010_1"
@@ -81,9 +82,10 @@ export default function MethodsModel(props) {
                                 // material={materials.green_02}
                             >
                                 <GrainMaterialYellow
+                                    opacity={opacity}
                                     boundingBox={boundingBox}
                                 />
-                                <Outlines />
+                                <Outlines opacity={opacity} />
                             </mesh>
                             <mesh
                                 name="gear_01001"
@@ -92,9 +94,10 @@ export default function MethodsModel(props) {
                                 position={[-0.264, -0.152, 0]}
                             >
                                 <GrainMaterialYellow
+                                    opacity={opacity}
                                     boundingBox={boundingBox}
                                 />
-                                <Outlines />
+                                <Outlines opacity={opacity} />
                             </mesh>
                             <mesh
                                 name="gear_02001"
@@ -103,9 +106,10 @@ export default function MethodsModel(props) {
                                 position={[0, 0.305, 0]}
                             >
                                 <GrainMaterialYellow
+                                    opacity={opacity}
                                     boundingBox={boundingBox}
                                 />
-                                <Outlines />
+                                <Outlines opacity={opacity} />
                             </mesh>
                             <mesh
                                 name="gear_03001"
@@ -114,9 +118,10 @@ export default function MethodsModel(props) {
                                 position={[0.264, -0.152, 0]}
                             >
                                 <GrainMaterialYellow
+                                    opacity={opacity}
                                     boundingBox={boundingBox}
                                 />
-                                <Outlines />
+                                <Outlines opacity={opacity} />
                             </mesh>
                             <mesh
                                 name="gear_04001"
@@ -124,9 +129,10 @@ export default function MethodsModel(props) {
                                 // material={materials.green_01}
                             >
                                 <GrainMaterialYellow
+                                    opacity={opacity}
                                     boundingBox={boundingBox}
                                 />
-                                <Outlines />
+                                <Outlines opacity={opacity} />
                             </mesh>
                         </group>
                     </group>

--- a/js/components/3D/Models/NorthfaceModel.jsx
+++ b/js/components/3D/Models/NorthfaceModel.jsx
@@ -10,7 +10,7 @@ import { GLB_ASSET_URLS } from "@/js/core/constants";
 import { GrainMaterialRed } from "../Materials";
 import { Outlines } from "../Common";
 
-export default function NorthfaceModel(props) {
+export default function NorthfaceModel({ opacity = 1, ...props }) {
     const [mounted, setMounted] = useState(false);
     const [boundingBox, setBoundingBox] = useState({
         min: new THREE.Vector3(0, 0, 0),
@@ -62,8 +62,11 @@ export default function NorthfaceModel(props) {
                             geometry={nodes.Plane001.geometry}
                             //   material={materials.green_01}
                         >
-                            <GrainMaterialRed boundingBox={boundingBox} />
-                            <Outlines />
+                            <GrainMaterialRed
+                                opacity={opacity}
+                                boundingBox={boundingBox}
+                            />
+                            <Outlines opacity={opacity} />
                         </mesh>
                     </group>
                 </group>

--- a/js/components/3D/Models/PhoneModel.jsx
+++ b/js/components/3D/Models/PhoneModel.jsx
@@ -7,7 +7,7 @@ import { useGLTF, useAnimations } from "@react-three/drei";
 
 import { GLB_ASSET_URLS } from "@/js/core/constants";
 
-export default function PhoneModel(props) {
+export default function PhoneModel({ opacity = 1, ...props }) {
     const group = useRef();
     const { nodes, animations } = useGLTF(GLB_ASSET_URLS.Phone);
     const { actions } = useAnimations(animations, group);

--- a/js/components/3D/Models/ShowreelModel.jsx
+++ b/js/components/3D/Models/ShowreelModel.jsx
@@ -10,7 +10,7 @@ import { GLB_ASSET_URLS } from "@/js/core/constants";
 import { GrainMaterialYellow, GrainMaterialYellowDark } from "../Materials";
 import { Outlines } from "../Common";
 
-export default function ShowreelModel(props) {
+export default function ShowreelModel({ opacity = 1, ...props }) {
     const [mounted, setMounted] = useState(false);
     const [boundingBox, setBoundingBox] = useState({
         min: new THREE.Vector3(0, 0, 0),
@@ -64,7 +64,10 @@ export default function ShowreelModel(props) {
                             rotation={[0, -0.262, 0]}
                             scale={0.908}
                         >
-                            <GrainMaterialYellow boundingBox={boundingBox} />
+                            <GrainMaterialYellow
+                                opacity={opacity}
+                                boundingBox={boundingBox}
+                            />
                             {/* <Outlines /> */}
                             <mesh
                                 name="bezel"
@@ -78,6 +81,7 @@ export default function ShowreelModel(props) {
                                 }
                             >
                                 <GrainMaterialYellowDark
+                                    opacity={opacity}
                                     boundingBox={boundingBox}
                                 />
                                 {/* <Outlines /> */}
@@ -90,6 +94,7 @@ export default function ShowreelModel(props) {
                                 scale={1.209}
                             >
                                 <GrainMaterialYellow
+                                    opacity={opacity}
                                     boundingBox={boundingBox}
                                 />
                                 {/* <Outlines /> */}

--- a/js/components/3D/Models/SkullModel.jsx
+++ b/js/components/3D/Models/SkullModel.jsx
@@ -10,7 +10,7 @@ import { GLB_ASSET_URLS } from "@/js/core/constants";
 import { GrainMaterialViolet, GrainMaterialVioletDark } from "../Materials";
 import { Outlines } from "../Common";
 
-export default function SkullModel(props) {
+export default function SkullModel({ opacity = 1, ...props }) {
     const [mounted, setMounted] = useState(false);
     const [boundingBox, setBoundingBox] = useState({
         min: new THREE.Vector3(0, 0, 0),
@@ -63,8 +63,11 @@ export default function SkullModel(props) {
                             //   material={materials.green_01}
                             position={[-0.004, -0.114, -0.039]}
                         >
-                            <GrainMaterialViolet boundingBox={boundingBox} />
-                            <Outlines />
+                            <GrainMaterialViolet
+                                opacity={opacity}
+                                boundingBox={boundingBox}
+                            />
+                            <Outlines opacity={opacity} />
                         </mesh>
                         <mesh
                             name="skull002"
@@ -72,17 +75,21 @@ export default function SkullModel(props) {
                             //   material={materials.green_01}
                             position={[-0.006, -0.152, 0.2]}
                         >
-                            <GrainMaterialViolet boundingBox={boundingBox} />
-                            <Outlines />
+                            <GrainMaterialViolet
+                                opacity={opacity}
+                                boundingBox={boundingBox}
+                            />
+                            <Outlines opacity={opacity} />
                             <mesh
                                 name="sockets"
                                 geometry={nodes.sockets.geometry}
                                 // material={materials.green_02}
                             >
                                 <GrainMaterialVioletDark
+                                    opacity={opacity}
                                     boundingBox={boundingBox}
                                 />
-                                <Outlines />
+                                <Outlines opacity={opacity} />
                             </mesh>
                         </mesh>
                     </group>

--- a/js/components/3D/Models/SosModel.jsx
+++ b/js/components/3D/Models/SosModel.jsx
@@ -9,7 +9,7 @@ import * as THREE from "three";
 import { GLB_ASSET_URLS } from "@/js/core/constants";
 import { GrainMaterialRed, OutlineMaterial } from "../Materials";
 
-export default function SosModel(props) {
+export default function SosModel({ opacity = 1, ...props }) {
     const [mounted, setMounted] = useState(false);
     const [boundingBox, setBoundingBox] = useState({
         min: new THREE.Vector3(0, 0, 0),
@@ -76,7 +76,10 @@ export default function SosModel(props) {
                             }
                             rotation={[0, -Math.PI / 6, 0]}
                         >
-                            <GrainMaterialRed boundingBox={boundingBox} />
+                            <GrainMaterialRed
+                                opacity={opacity}
+                                boundingBox={boundingBox}
+                            />
                         </mesh>
                         <mesh
                             name="fish_outline"
@@ -90,7 +93,7 @@ export default function SosModel(props) {
                             }
                             rotation={[0, -Math.PI / 6, 0]}
                         >
-                            <OutlineMaterial />
+                            <OutlineMaterial opacity={opacity} />
                         </mesh>
                     </group>
                 </group>

--- a/js/components/3D/Models/StoriesModel.jsx
+++ b/js/components/3D/Models/StoriesModel.jsx
@@ -10,7 +10,7 @@ import { GLB_ASSET_URLS } from "@/js/core/constants";
 import { GrainMaterialYellow, GrainMaterialYellowDark } from "../Materials";
 import { Outlines } from "../Common";
 
-export default function StoriesModel(props) {
+export default function StoriesModel({ opacity = 1, ...props }) {
     const [mounted, setMounted] = useState(false);
     const [boundingBox, setBoundingBox] = useState({
         min: new THREE.Vector3(0, 0, 0),
@@ -67,17 +67,21 @@ export default function StoriesModel(props) {
                             //   material={materials.green_01}
                             position={[-0.152, -0.327, 0.498]}
                         >
-                            <GrainMaterialYellow boundingBox={boundingBox} />
-                            <Outlines />
+                            <GrainMaterialYellow
+                                opacity={opacity}
+                                boundingBox={boundingBox}
+                            />
+                            <Outlines opacity={opacity} />
                             <mesh
                                 name="tac"
                                 geometry={nodes.tac.geometry}
                                 // material={materials.green_02}
                             >
                                 <GrainMaterialYellowDark
+                                    opacity={opacity}
                                     boundingBox={boundingBox}
                                 />
-                                <Outlines />
+                                <Outlines opacity={opacity} />
                             </mesh>
                         </mesh>
                         <mesh
@@ -86,17 +90,21 @@ export default function StoriesModel(props) {
                             // material={materials.green_01}
                             position={[0.239, -0.024, 0.417]}
                         >
-                            <GrainMaterialYellow boundingBox={boundingBox} />
-                            <Outlines />
+                            <GrainMaterialYellow
+                                opacity={opacity}
+                                boundingBox={boundingBox}
+                            />
+                            <Outlines opacity={opacity} />
                             <mesh
                                 name="cat"
                                 geometry={nodes.cat.geometry}
                                 // material={materials.green_02}
                             >
                                 <GrainMaterialYellowDark
+                                    opacity={opacity}
                                     boundingBox={boundingBox}
                                 />
-                                <Outlines />
+                                <Outlines opacity={opacity} />
                             </mesh>
                         </mesh>
                         <mesh
@@ -105,17 +113,21 @@ export default function StoriesModel(props) {
                             //   material={materials.green_01}
                             position={[-0.192, 0.273, 0.328]}
                         >
-                            <GrainMaterialYellow boundingBox={boundingBox} />
-                            <Outlines />
+                            <GrainMaterialYellow
+                                opacity={opacity}
+                                boundingBox={boundingBox}
+                            />
+                            <Outlines opacity={opacity} />
                             <mesh
                                 name="act"
                                 geometry={nodes.act.geometry}
                                 // material={materials.green_02}
                             >
                                 <GrainMaterialYellowDark
+                                    opacity={opacity}
                                     boundingBox={boundingBox}
                                 />
-                                <Outlines />
+                                <Outlines opacity={opacity} />
                             </mesh>
                         </mesh>
                     </group>

--- a/js/components/3D/Models/WorkModel.jsx
+++ b/js/components/3D/Models/WorkModel.jsx
@@ -13,7 +13,7 @@ import {
     OutlineMaterial,
 } from "../Materials";
 
-export default function WorkModel(props) {
+export default function WorkModel({ opacity = 1, ...props }) {
     const [mounted, setMounted] = useState(false);
     const [boundingBox, setBoundingBox] = useState({
         min: new THREE.Vector3(0, 0, 0),
@@ -74,7 +74,10 @@ export default function WorkModel(props) {
                             }
                             position={[0.026, -0.067, -0.021]}
                         >
-                            <GrainMaterialYellow boundingBox={boundingBox} />
+                            <GrainMaterialYellow
+                                opacity={opacity}
+                                boundingBox={boundingBox}
+                            />
                         </mesh>
                         <mesh
                             name="hand_outline"
@@ -88,7 +91,7 @@ export default function WorkModel(props) {
                             }
                             position={[0.026, -0.067, -0.021]}
                         >
-                            <OutlineMaterial />
+                            <OutlineMaterial opacity={opacity} />
                         </mesh>
                         <mesh
                             name="tie"
@@ -103,6 +106,7 @@ export default function WorkModel(props) {
                             position={[0.026, -0.067, -0.021]}
                         >
                             <GrainMaterialYellowDark
+                                opacity={opacity}
                                 boundingBox={boundingBox}
                             />
                         </mesh>
@@ -118,7 +122,7 @@ export default function WorkModel(props) {
                             }
                             position={[0.026, -0.067, -0.021]}
                         >
-                            <OutlineMaterial />
+                            <OutlineMaterial opacity={opacity} />
                         </mesh>
                     </group>
                 </group>

--- a/js/components/3D/Shaders/GrainShaderMaterial/fragment.glsl
+++ b/js/components/3D/Shaders/GrainShaderMaterial/fragment.glsl
@@ -21,6 +21,7 @@ uniform bool uGradientEnabled;
 uniform bool uNoiseEnabled;
 uniform float uNoiseContrast;
 uniform float uNoiseScalarDistanceFactor;
+uniform float opacity;
 
 varying vec2 vScreenSpace;
 varying vec2 vUv;
@@ -121,5 +122,5 @@ void main() {
         color += noiseColor;
     }
 
-    gl_FragColor = vec4(color, 1.0);
+    gl_FragColor = vec4(color, opacity);
 }

--- a/js/components/3D/Shaders/GrainShaderMaterial/index.js
+++ b/js/components/3D/Shaders/GrainShaderMaterial/index.js
@@ -28,6 +28,7 @@ export const GrainShaderMaterial = shaderMaterial(
         uNoiseScale: 1000.0,
         uNoiseContrast: 1.5,
         uNoiseScalarDistanceFactor: 1.5,
+        opacity: 1.0,
     },
     // Vertex Shader
     `${vertexShaderCode}`,

--- a/js/components/3D/Shaders/GrainShaderMaterialB/fragment.glsl
+++ b/js/components/3D/Shaders/GrainShaderMaterialB/fragment.glsl
@@ -21,6 +21,7 @@ uniform bool uGradientEnabled;
 uniform bool uNoiseEnabled;
 uniform float uNoiseContrast;
 uniform float uNoiseScalarDistanceFactor;
+uniform float opacity;
 
 varying vec2 vScreenSpace;
 varying vec2 vUv;
@@ -121,5 +122,5 @@ void main() {
         color = color * gradientColor;
     }
 
-    gl_FragColor = vec4(color, 1.0);
+    gl_FragColor = vec4(color, opacity);
 }

--- a/js/components/3D/Shaders/GrainShaderMaterialB/index.js
+++ b/js/components/3D/Shaders/GrainShaderMaterialB/index.js
@@ -28,6 +28,7 @@ export const GrainShaderMaterialB = shaderMaterial(
         uNoiseScale: 1000.0,
         uNoiseContrast: 1.5,
         uNoiseScalarDistanceFactor: 1.5,
+        opacity: 1.0,
     },
     // Vertex Shader
     `${vertexShaderCode}`,

--- a/js/components/HomeScene/HomeScene.jsx
+++ b/js/components/HomeScene/HomeScene.jsx
@@ -3,6 +3,7 @@ import styles from "./HomeScene.module.scss";
 import { Suspense, lazy, useRef } from "react";
 import { Canvas } from "@react-three/fiber";
 import { Leva } from "leva";
+
 import { debug } from "@/js/core/constants";
 import { useStore } from "@/js/lib/store";
 import Loading from "./Loading";
@@ -32,9 +33,14 @@ export default function HomeScene() {
             <div className={styles.canvasWrapper} {...wrapperProps} ref={ref}>
                 <Canvas
                     shadows
-                    onCreated={({ get }) => {
+                    onCreated={({ get, gl }) => {
                         // Pass r3f store getter to our local store
                         setGetR3fStore(get);
+                        gl.setClearAlpha(0);
+                    }}
+                    gl={{
+                        antialias: true,
+                        alpha: true,
                     }}
                 >
                     <Suspense fallback={<Loading />}>

--- a/js/components/HomeScene/Nav/Nav.jsx
+++ b/js/components/HomeScene/Nav/Nav.jsx
@@ -163,11 +163,12 @@ const NavArrows = ({ visible }) => {
     const el = useRef(null);
     const orbit = useStore((state) => state.orbit);
     useLayoutEffect(() => {
-        if (!el.current) {
+        const target = el.current;
+        if (!target) {
             return;
         }
         gsap.fromTo(
-            el.current,
+            target,
             {
                 opacity: visible ? 0 : 1,
                 y: visible ? 50 : 0,
@@ -183,7 +184,7 @@ const NavArrows = ({ visible }) => {
             },
         );
         return () => {
-            gsap.killTweensOf(el.current);
+            gsap.killTweensOf(target);
         };
     }, [visible]);
     return (
@@ -204,11 +205,12 @@ const NavBack = ({ visible }) => {
     const el = useRef(null);
     const resetCurrentBoxUuid = useStore((state) => state.resetCurrentBoxUuid);
     useLayoutEffect(() => {
-        if (!el.current) {
+        const target = el.current;
+        if (!target) {
             return;
         }
         gsap.fromTo(
-            el.current,
+            target,
             {
                 opacity: visible ? 0 : 1,
                 y: visible ? 50 : 0,
@@ -224,7 +226,7 @@ const NavBack = ({ visible }) => {
             },
         );
         return () => {
-            gsap.killTweensOf(el.current);
+            gsap.killTweensOf(target);
         };
     }, [visible]);
     return (

--- a/js/components/HomeScene/Nav/Nav.jsx
+++ b/js/components/HomeScene/Nav/Nav.jsx
@@ -1,9 +1,10 @@
 import styles from "./Nav.module.scss";
 
-import { useMemo, useState } from "react";
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import cx from "classnames";
 
+import gsap from "@/js/lib/gsap";
 import { useStore } from "@/js/lib/store";
 import Actions from "./Actions";
 
@@ -158,10 +159,35 @@ const Button = ({
     );
 };
 
-const NavArrows = () => {
+const NavArrows = ({ visible }) => {
+    const el = useRef(null);
     const orbit = useStore((state) => state.orbit);
+    useLayoutEffect(() => {
+        if (!el.current) {
+            return;
+        }
+        gsap.fromTo(
+            el.current,
+            {
+                opacity: visible ? 0 : 1,
+                y: visible ? 50 : 0,
+                zIndex: visible ? -1 : 1,
+                visibility: visible ? "hidden" : "visible",
+            },
+            {
+                opacity: visible ? 1 : 0,
+                y: visible ? 0 : 50,
+                zIndex: visible ? 1 : -1,
+                visibility: visible ? "visible" : "hidden",
+                duration: 0.2,
+            },
+        );
+        return () => {
+            gsap.killTweensOf(el.current);
+        };
+    }, [visible]);
     return (
-        <div className={styles.arrowsWrapper}>
+        <div className={styles.arrowsWrapper} ref={el}>
             <div className={styles.buttonWrapper}>
                 <Button direction="left" onClick={orbit} />
                 <div className={styles.middleButtons}>
@@ -174,10 +200,35 @@ const NavArrows = () => {
     );
 };
 
-const NavBack = () => {
+const NavBack = ({ visible }) => {
+    const el = useRef(null);
     const resetCurrentBoxUuid = useStore((state) => state.resetCurrentBoxUuid);
+    useLayoutEffect(() => {
+        if (!el.current) {
+            return;
+        }
+        gsap.fromTo(
+            el.current,
+            {
+                opacity: visible ? 0 : 1,
+                y: visible ? 50 : 0,
+                zIndex: visible ? -1 : 1,
+                visibility: visible ? "hidden" : "visible",
+            },
+            {
+                opacity: visible ? 1 : 0,
+                y: visible ? 0 : 50,
+                zIndex: visible ? 1 : -1,
+                visibility: visible ? "visible" : "hidden",
+                duration: 0.2,
+            },
+        );
+        return () => {
+            gsap.killTweensOf(el.current);
+        };
+    }, [visible]);
     return (
-        <div className={styles.backWrapper}>
+        <div className={styles.backWrapper} ref={el}>
             <Button
                 direction="left"
                 onClick={() => {
@@ -193,14 +244,22 @@ const NavUi = () => {
     const interactable = useStore((state) => state.interactable);
     const currentBoxUuid = useStore((state) => state.currentBoxUuid);
 
+    const isNavBackVisible = useMemo(() => {
+        return typeof currentBoxUuid === "string";
+    }, [currentBoxUuid]);
+
+    const isNavArrowsVisible = useMemo(() => {
+        return currentBoxUuid === null;
+    }, [currentBoxUuid]);
+
     if (!interactable) {
         return null;
     }
 
     return (
         <>
-            <NavBack visible={typeof currentBoxUuid === "string"} />
-            <NavArrows visible={currentBoxUuid === null} />
+            <NavBack visible={isNavBackVisible} />
+            <NavArrows visible={isNavArrowsVisible} />
         </>
     );
 };

--- a/js/components/HomeScene/Nav/Nav.module.scss
+++ b/js/components/HomeScene/Nav/Nav.module.scss
@@ -8,6 +8,7 @@
     position: absolute;
     bottom: 80px;
     left: 80px;
+    opacity: 0;
 }
 
 .buttonWrapper {

--- a/js/components/HomeScene/Scene/Box.jsx
+++ b/js/components/HomeScene/Scene/Box.jsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+    cloneElement,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from "react";
 import { useThree } from "@react-three/fiber";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
@@ -18,6 +25,15 @@ export default function Box({ children, ...rest }) {
     const clickEnabled = useMemo(() => {
         return currentBoxUuid === null;
     }, [currentBoxUuid]);
+
+    const isCurrentBox = useMemo(() => {
+        return currentBoxUuid === ref.current?.children[0]?.uuid;
+    }, [currentBoxUuid]);
+
+    const Child = cloneElement(children, {
+        extraProp: "Some extra prop",
+        opacity: isCurrentBox ? 1 : children.props.opacity, // override opacity when selected
+    });
 
     const refClone = useMemo(() => {
         if (mounted) {
@@ -58,7 +74,7 @@ export default function Box({ children, ...rest }) {
 
     return (
         <group ref={ref} {...rest} onClick={handleClick}>
-            {children}
+            {Child}
         </group>
     );
 }

--- a/js/components/HomeScene/Scene/Model.jsx
+++ b/js/components/HomeScene/Scene/Model.jsx
@@ -31,6 +31,7 @@ function Model(props) {
     const setTriptychModelUuid = useStore(
         (state) => state.setTriptychModelUuid,
     );
+    const opacity = useStore((state) => state.homeSceneOpacity);
     const [boundingBox, setBoundingBox] = useState({
         min: new THREE.Vector3(0, 0, 0),
         max: new THREE.Vector3(1, 1, 1),
@@ -128,11 +129,10 @@ function Model(props) {
         <group {...props} dispose={null} scale={0.1}>
             <mesh
                 name="Triptych"
-                castShadow
-                receiveShadow
                 geometry={nodes.triptych.geometry}
                 // material={nodes.triptych.material}
                 ref={tripTychRef}
+                visible={true}
             >
                 <grainShaderMaterial
                     uNoiseEnabled={uNoiseEnabled}
@@ -146,8 +146,10 @@ function Model(props) {
                     uGradientEnabled={uGradientEnabled}
                     ref={grainShaderMaterialRef}
                     key={GrainShaderMaterial.key}
+                    opacity={opacity}
+                    transparent
                 />
-                <Outlines />
+                <Outlines opacity={opacity} />
             </mesh>
             {/* <mesh
                 castShadow
@@ -163,7 +165,7 @@ function Model(props) {
                 position={[1, 1, -3]}
             /> */}
             <Box position={[1, 1, -3]}>
-                <CareersModel />
+                <CareersModel opacity={opacity} />
             </Box>
             {/* <mesh
                 castShadow
@@ -174,7 +176,7 @@ function Model(props) {
                 scale={0.5}
             /> */}
             <Box position={[1, 3, -3]}>
-                <EpbModel />
+                <EpbModel opacity={opacity} />
             </Box>
             {/* <mesh
                 castShadow
@@ -184,7 +186,7 @@ function Model(props) {
                 position={[-3, -1, -3]}
             /> */}
             <Box position={[-3, -1, -3]}>
-                <GyroModel />
+                <GyroModel opacity={opacity} />
             </Box>
             {/* <mesh
                 castShadow
@@ -194,7 +196,7 @@ function Model(props) {
                 position={[-3, 3, 1]}
             /> */}
             <Box position={[-3, 3, 1]}>
-                <CultureModel />
+                <CultureModel opacity={opacity} />
             </Box>
             {/* <mesh
                 castShadow
@@ -205,7 +207,7 @@ function Model(props) {
                 scale={0.5}
             /> */}
             <Box position={[-1, -1, 1]}>
-                <ShowreelModel />
+                <ShowreelModel opacity={opacity} />
             </Box>
             {/* <mesh
                 castShadow
@@ -215,7 +217,7 @@ function Model(props) {
                 position={[3, -1, 3]}
             /> */}
             <Box position={[3, -1, 3]}>
-                <WorkModel />
+                <WorkModel opacity={opacity} />
             </Box>
             {/* <mesh
                 castShadow
@@ -225,7 +227,7 @@ function Model(props) {
                 position={[-1, -3, 1]}
             /> */}
             <Box position={[-1, -3, 1]}>
-                <StoriesModel />
+                <StoriesModel opacity={opacity} />
             </Box>
             <mesh
                 castShadow
@@ -236,7 +238,7 @@ function Model(props) {
                 scale={0.5}
             />
             <Box position={[1, -1, -1]}>
-                <ContactModel />
+                <ContactModel opacity={opacity} />
             </Box>
             {/* <mesh
                 castShadow
@@ -247,7 +249,7 @@ function Model(props) {
                 scale={0.5}
             /> */}
             <Box position={[-1, 3, 3]}>
-                <MethodsModel />
+                <MethodsModel opacity={opacity} />
             </Box>
             {/* <mesh
                 castShadow
@@ -257,7 +259,7 @@ function Model(props) {
                 position={[-3, -3, -3]}
             /> */}
             <Box position={[-3, -3, -3]}>
-                <CdmModel />
+                <CdmModel opacity={opacity} />
             </Box>
             {/* <mesh
                 castShadow
@@ -267,7 +269,7 @@ function Model(props) {
                 position={[3, 3, -1]}
             /> */}
             <Box position={[3, 3, -1]}>
-                <SosModel />
+                <SosModel opacity={opacity} />
             </Box>
             {/* <mesh
                 castShadow
@@ -278,7 +280,7 @@ function Model(props) {
                 scale={0.5}
             /> */}
             <Box position={[3, -3, -1]}>
-                <NorthfaceModel />
+                <NorthfaceModel opacity={opacity} />
             </Box>
             {/* <mesh
                 castShadow
@@ -288,7 +290,7 @@ function Model(props) {
                 position={[1, -3, 1]}
             /> */}
             <Box position={[1, -3, 1]}>
-                <SkullModel />
+                <SkullModel opacity={opacity} />
             </Box>
             {/* <mesh
                 castShadow
@@ -298,7 +300,7 @@ function Model(props) {
                 position={[-1, 1, 1]}
             /> */}
             <Box position={[-1, 1, 1]}>
-                <EyeModel />
+                <EyeModel opacity={opacity} />
             </Box>
             {/* <mesh
                 castShadow
@@ -308,7 +310,7 @@ function Model(props) {
                 position={[3, 1, 3]}
             /> */}
             <Box position={[3, 1, 3]}>
-                <KeyModel />
+                <KeyModel opacity={opacity} />
             </Box>
         </group>
     );

--- a/js/components/HomeScene/Scene/Model.jsx
+++ b/js/components/HomeScene/Scene/Model.jsx
@@ -229,14 +229,14 @@ function Model(props) {
             <Box position={[-1, -3, 1]}>
                 <StoriesModel opacity={opacity} />
             </Box>
-            <mesh
+            {/* <mesh
                 castShadow
                 receiveShadow
                 geometry={nodes.location_007.geometry}
                 material={nodes.location_007.material}
                 position={[1, -1, -1]}
                 scale={0.5}
-            />
+            /> */}
             <Box position={[1, -1, -1]}>
                 <ContactModel opacity={opacity} />
             </Box>

--- a/js/components/HomeScene/Scene/Rig.jsx
+++ b/js/components/HomeScene/Scene/Rig.jsx
@@ -35,7 +35,7 @@ export default function Rig() {
 
     const { lookAtMeshVisible, lookAtFactor } = useControls({
         Rig: folder({
-            lookAtMeshVisible: debug,
+            lookAtMeshVisible: false,
             lookAtFactor: {
                 value: 8,
                 min: 0.1,
@@ -74,7 +74,7 @@ export default function Rig() {
                 cameraOrbitPoint.current.y,
                 cameraOrbitPoint.current.z,
             );
-            await cameraControls.fitToBox(cameraTarget, true, {
+            await cameraControls.fitToBox(cameraTarget, false, {
                 paddingTop: paddingTop,
                 paddingRight: paddingRight,
                 paddingBottom: paddingBottom,

--- a/js/components/HomeScene/Scene/Rig.jsx
+++ b/js/components/HomeScene/Scene/Rig.jsx
@@ -74,7 +74,7 @@ export default function Rig() {
                 cameraOrbitPoint.current.y,
                 cameraOrbitPoint.current.z,
             );
-            await cameraControls.fitToBox(cameraTarget, false, {
+            await cameraControls.fitToBox(cameraTarget, true, {
                 paddingTop: paddingTop,
                 paddingRight: paddingRight,
                 paddingBottom: paddingBottom,
@@ -101,7 +101,6 @@ export default function Rig() {
         paddingLeft,
         introPlayed,
         intro,
-        debug,
     ]);
 
     useEffect(() => {

--- a/js/components/HomeScene/Scene/Scene.jsx
+++ b/js/components/HomeScene/Scene/Scene.jsx
@@ -1,4 +1,4 @@
-import { Environment } from "@react-three/drei";
+// import { Environment } from "@react-three/drei";
 import { Perf } from "r3f-perf";
 
 import { debug } from "@/js/core/constants";
@@ -16,7 +16,7 @@ export default function Scene() {
             <Rig />
 
             {/* environment */}
-            <Environment preset="sunset" blur={1} />
+            {/* <Environment preset="sunset" blur={1} /> */}
 
             {/* models */}
             <Model />

--- a/js/lib/store/homeSceneSlice.js
+++ b/js/lib/store/homeSceneSlice.js
@@ -20,6 +20,8 @@ export const createHomeSceneSlice = (set, get) => ({
     getR3fStore: () => {},
     setGetR3fStore: (getR3fStore) => set(() => ({ getR3fStore })),
 
+    homeSceneOpacity: debug ? 1.0 : 0.0,
+
     /**
      * @type {(null | string)}
      */
@@ -137,12 +139,6 @@ export const createHomeSceneSlice = (set, get) => ({
         if (!cameraControls) return;
 
         const scene = get().getR3fStore().scene;
-        const triptychModelUuid = get().triptychModelUuid;
-        const triptychModel = scene.getObjectByProperty(
-            "uuid",
-            triptychModelUuid,
-        );
-        const triptychModelMaterial = triptychModel.material;
         const cameraTargetUuid = get().cameraTargetUuid;
         const cameraTarget = scene.getObjectByProperty(
             "uuid",
@@ -160,30 +156,39 @@ export const createHomeSceneSlice = (set, get) => ({
         const boundingSphere = cameraTarget.geometry.boundingSphere.clone();
         boundingSphere.getBoundingBox(boundingBox);
 
-        triptychModelMaterial.opacity = 0.0;
+        cameraControls.smoothTime = 0.5;
+
+        const obj = {
+            opacity: 0.0,
+        };
         gsap.fromTo(
-            triptychModelMaterial,
+            obj,
             { opacity: 0.0 },
             {
                 opacity: 1.0,
-                duration: 1,
+                duration: 2,
+                onUpdate: () => {
+                    set({ homeSceneOpacity: obj.opacity });
+                },
             },
         );
-        cameraControls.smoothTime = 0.5;
-
         await cameraControls.rotate(
             THREE.MathUtils.degToRad(135),
             THREE.MathUtils.degToRad(-45),
-            true,
+            false,
         );
 
+        cameraControls.smoothTime = 0.4;
+
         await cameraControls.rotate(
-            THREE.MathUtils.degToRad(135),
+            THREE.MathUtils.degToRad(-135),
             THREE.MathUtils.degToRad(45),
             true,
         );
 
         cameraControls.smoothTime = 0.25;
+
+        cameraControls.normalizeRotations();
 
         set({ introPlayed: true, interactable: true });
     },

--- a/js/lib/store/homeSceneSlice.js
+++ b/js/lib/store/homeSceneSlice.js
@@ -40,8 +40,47 @@ export const createHomeSceneSlice = (set, get) => ({
      *
      * @param {string} uuid UUID of object3d or mesh to focus
      */
-    setCurrentBoxUuid: (uuid) => set(() => ({ currentBoxUuid: uuid })),
-    resetCurrentBoxUuid: () => set(() => ({ currentBoxUuid: null })),
+    setCurrentBoxUuid: async (uuid) => {
+        const obj = {
+            opacity: 1.0,
+        };
+
+        gsap.fromTo(
+            obj,
+            { opacity: 1.0 },
+            {
+                opacity: 0.0,
+                duration: 0.25,
+                ease: "power2.inOut",
+                onStart: () => {
+                    set(() => ({ currentBoxUuid: uuid }));
+                },
+                onUpdate: () => {
+                    set({ homeSceneOpacity: obj.opacity });
+                },
+            },
+        );
+    },
+    resetCurrentBoxUuid: async () => {
+        const obj = {
+            opacity: 0.0,
+        };
+        gsap.fromTo(
+            obj,
+            { opacity: 0.0 },
+            {
+                opacity: 1.0,
+                duration: 0.25,
+                ease: "power2.inOut",
+                onUpdate: () => {
+                    set({ homeSceneOpacity: obj.opacity });
+                },
+                onComplete: () => {
+                    set(() => ({ currentBoxUuid: null }));
+                },
+            },
+        );
+    },
 
     /**
      * @type {(null | string)}

--- a/js/lib/store/homeSceneSlice.js
+++ b/js/lib/store/homeSceneSlice.js
@@ -156,37 +156,38 @@ export const createHomeSceneSlice = (set, get) => ({
         const boundingSphere = cameraTarget.geometry.boundingSphere.clone();
         boundingSphere.getBoundingBox(boundingBox);
 
-        cameraControls.smoothTime = 0.5;
-
         const obj = {
             opacity: 0.0,
         };
+
         gsap.fromTo(
             obj,
             { opacity: 0.0 },
             {
                 opacity: 1.0,
-                duration: 2,
+                duration: 0.25,
+                ease: "power2.inOut",
                 onUpdate: () => {
                     set({ homeSceneOpacity: obj.opacity });
                 },
             },
         );
+
+        cameraControls.smoothTime = 0.5;
+
         await cameraControls.rotate(
-            THREE.MathUtils.degToRad(135),
             THREE.MathUtils.degToRad(-45),
-            false,
-        );
-
-        cameraControls.smoothTime = 0.4;
-
-        await cameraControls.rotate(
-            THREE.MathUtils.degToRad(-135),
-            THREE.MathUtils.degToRad(45),
+            THREE.MathUtils.degToRad(-45),
             true,
         );
 
-        cameraControls.smoothTime = 0.25;
+        cameraControls.smoothTime = 0.25; // reset back to default
+
+        await cameraControls.rotate(
+            THREE.MathUtils.degToRad(-45),
+            THREE.MathUtils.degToRad(45),
+            true,
+        );
 
         cameraControls.normalizeRotations();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -808,9 +808,9 @@
   integrity sha512-POu8Mk0hIU3lRXB3bGIGe4VHIwwDsQyoD1F394OK7STTiX9w4dG3cTLljjYswkQN+hDSHRrj4O36kuVa7KPU8Q==
 
 "@react-three/drei@^9.56.10", "@react-three/drei@^9.83.1":
-  version "9.85.0"
-  resolved "https://registry.yarnpkg.com/@react-three/drei/-/drei-9.85.0.tgz#c314c39a3ff9ed5257e82291263f0a8552b0756e"
-  integrity sha512-9Cd/xY48eVUgFQy6LId9wt7jBS/KiJ1warPiYAVPhVuhL2xth++lJ/LndYfRZ+0CVfDes0uk+01zjD6QXWBzOQ==
+  version "9.86.0"
+  resolved "https://registry.yarnpkg.com/@react-three/drei/-/drei-9.86.0.tgz#aad033774c414105b72ef02df7a7d140942e7fc3"
+  integrity sha512-7QfieQwDe8zgLbGtr/rdusj/zQQXK0D8yA0U+bv+VJZrTtXEl1fYJtHxsxWcS95N+sgff5k6QyxwCUy2q3bHCg==
   dependencies:
     "@babel/runtime" "^7.11.2"
     "@mediapipe/tasks-vision" "0.10.2"
@@ -830,7 +830,7 @@
     stats-gl "^1.0.4"
     stats.js "^0.17.0"
     suspend-react "^0.1.3"
-    three-mesh-bvh "^0.6.0"
+    three-mesh-bvh "^0.6.7"
     three-stdlib "^2.26.6"
     troika-three-text "^0.47.2"
     utility-types "^3.10.0"
@@ -883,9 +883,9 @@
   integrity sha512-9g9dWI4gsSVe8bNLlb+lMkBYsnIKCZTmvqvDG+Avnn69XfmHZKiaMrx7cgTaddq7aTPPmXiTsbFcUy0xgI4+wA==
 
 "@studio-freight/lenis@^1.0.19":
-  version "1.0.23"
-  resolved "https://registry.yarnpkg.com/@studio-freight/lenis/-/lenis-1.0.23.tgz#b190531065b330353331fbfd4b92d73897289be6"
-  integrity sha512-eV/mGeHzP3D6eEH762CYBOQUMScy6ye9mhmT+GLMx10WaP7tB9OsX4kBBF4WeLgvi5ot4M3XaN2dgoLblNygRQ==
+  version "1.0.24"
+  resolved "https://registry.yarnpkg.com/@studio-freight/lenis/-/lenis-1.0.24.tgz#e803c5e93a680c6336999c07b3863076efcd4095"
+  integrity sha512-lOd+vy62k/ekOEU0PLXjHIpobVKBYeBEiy0T3x6MrvgG5ohbP3+iVRZAUAdw94Sv2jk6AgowwJqifB9pC/qc9Q==
 
 "@thi.ng/api@^8.9.5":
   version "8.9.5"
@@ -1114,9 +1114,9 @@
     "@babel/types" "^7.20.7"
 
 "@types/draco3d@^1.4.0":
-  version "1.4.5"
-  resolved "https://registry.yarnpkg.com/@types/draco3d/-/draco3d-1.4.5.tgz#cb78109d7641b7c23c7c1d9a645eb4f93754a9e9"
-  integrity sha512-JdcOl2fwoCZOHGZErjnrku3h6hF/8D21VBCclyP4m9Kggh+vMXsLyAmfEiOXwUXZ1jpv2jdfWV/a5NCgw/g/Kg==
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/@types/draco3d/-/draco3d-1.4.6.tgz#7214bf6c67afbc8637a57c49f2daa52b5d4c3268"
+  integrity sha512-tAyEGmnz6qcPqSWoHtO3tTobQCDW0tW36gVdDKyN0jkT2S2w6LABe0+DdVkfVDwNzTwR7cE7LQGiGJiAsdSNKg==
 
 "@types/eslint@^8.4.5":
   version "8.44.3"
@@ -1147,9 +1147,9 @@
   integrity sha512-FbtmBWCcSa2J4zL781Zf1p5YUBXQomPEcep9QZCfRfQgTxz3pJWiDFLebohZ9fFntX5ibzOkSsrJ0TEew8cAog==
 
 "@types/react-dom@^18.2.7":
-  version "18.2.7"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.7.tgz#67222a08c0a6ae0a0da33c3532348277c70abb63"
-  integrity sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==
+  version "18.2.8"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.8.tgz#338f1b0a646c9f10e0a97208c1d26b9f473dffd6"
+  integrity sha512-bAIvO5lN/U8sPGvs1Xm61rlRHHaq5rp5N3kp9C+NJ/Q41P8iqjkXSu0+/qu8POsjH9pNWb0OYabFez7taP7omw==
   dependencies:
     "@types/react" "*"
 
@@ -1161,9 +1161,9 @@
     "@types/react" "*"
 
 "@types/react-reconciler@^0.28.0":
-  version "0.28.4"
-  resolved "https://registry.yarnpkg.com/@types/react-reconciler/-/react-reconciler-0.28.4.tgz#c2c06f6d42f055972290eecebb87b10d0ac66e0e"
-  integrity sha512-Xd55E2aLI9Q/ikDQEmfRzIwYJs4oO0h9ZHA3FZDakzt1WR6JMZcpqtCZlF97I72KVjoY4rHXU5TfvkRDOyr/rg==
+  version "0.28.5"
+  resolved "https://registry.yarnpkg.com/@types/react-reconciler/-/react-reconciler-0.28.5.tgz#cf3865d09973963ae73fddb01d40a8535d900bde"
+  integrity sha512-Qrwgl4NxNYH1oAJSJtlMGu95uaeMqrGiKzxwI90VvofBkJAj4GxcCAsJMZkwdR/qAxlm84YEXa8Fqu2xXk0arw==
   dependencies:
     "@types/react" "*"
 
@@ -1460,9 +1460,9 @@ camera-controls@^2.4.2, camera-controls@^2.7.1:
   integrity sha512-6+gaZFK3LYbWaXC94EN0BYLlvpo9xfUqwp59vsU3nV7WXIU05q4wyP5TOgyG1tqTHReuBofb20vKfZNBNjMtzw==
 
 caniuse-lite@^1.0.30001539:
-  version "1.0.30001539"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001539.tgz#325a387ab1ed236df2c12dc6cd43a4fff9903a44"
-  integrity sha512-hfS5tE8bnNiNvEOEkm8HElUHroYwlqMMENEzELymy77+tJ6m+gA2krtHl5hxJaj71OlpC2cHZbdSMX1/YEqEkA==
+  version "1.0.30001541"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001541.tgz#b1aef0fadd87fb72db4dcb55d220eae17b81cdb1"
+  integrity sha512-bLOsqxDgTqUBkzxbNlSBt8annkDpQB9NdzdTbO2ooJ+eC/IQcvDspDc058g84ejCelF7vHUx57KIOjEecOHXaw==
 
 chalk@^2.4.2:
   version "2.4.2"
@@ -1645,9 +1645,9 @@ draco3d@^1.4.1:
   integrity sha512-+3NaRjWktb5r61ZFoDejlykPEFKT5N/LkbXsaddlw6xNSXBanUYpFc2AXXpbJDilPHazcSreU/DpQIaxfX0NfQ==
 
 electron-to-chromium@^1.4.530:
-  version "1.4.531"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.531.tgz#22966d894c4680726c17cf2908ee82ff5d26ac25"
-  integrity sha512-H6gi5E41Rn3/mhKlPaT1aIMg/71hTAqn0gYEllSuw9igNWtvQwu185jiCZoZD29n7Zukgh7GVZ3zGf0XvkhqjQ==
+  version "1.4.532"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.532.tgz#44454731e26f2c8c14e88cca0d073f0761784f5e"
+  integrity sha512-piIR0QFdIGKmOJTSNg5AwxZRNWQSXlRYycqDB9Srstx4lip8KpcmRxVP6zuFWExWziHYZpJ0acX7TxqX95KBpg==
 
 es-abstract@^1.22.1:
   version "1.22.2"
@@ -3253,7 +3253,7 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
-three-mesh-bvh@^0.6.0:
+three-mesh-bvh@^0.6.7:
   version "0.6.7"
   resolved "https://registry.yarnpkg.com/three-mesh-bvh/-/three-mesh-bvh-0.6.7.tgz#6491876f5bf0c0d67be81a4402f2abdbb2266d76"
   integrity sha512-RYdjMsH+vZvjLwA+ehI4+ZqTaTehAz4iho2yfL5PdGsIHyxpB78g0iy4Emj8079m/9KBX02TzddkvPSKSruQjg==


### PR DESCRIPTION
- Allow shaders to inherit opacity
- Comment out environment
- Allow all models to inherit opacity
- Don't tween resize/fitToBox
- Create global home scene opacity value
- Setup home scene transaparency
- Wire in home scene opacity value
- Hide placeholder mesh
- Add missing opacity
- Tween resizes
- Cleanup intro animation
- Setup nav tweening
- Reinstall packages
- Cleanup artifacts
- Setup box to calc opacity of child models
- Setup actions for fade in/out of scene
