### PR TITLE
enhancement/camera controls redux

### DIFF
--- a/js/components/3D/Materials/index.jsx
+++ b/js/components/3D/Materials/index.jsx
@@ -277,13 +277,13 @@ export const WaterMaterial = ({ opacity = 1 }) => {
             Perlin: folder({
                 uPerlinEnabled: true,
                 uPerlinResolution: {
-                    value: 75,
+                    value: 4,
                     min: 1,
                     max: 100,
                     step: 1,
                 },
                 uPerlinYScale: {
-                    value: 21,
+                    value: 9,
                     min: 1.0,
                     max: 50.0,
                     step: 1.0,

--- a/js/components/3D/Shaders/WaterShaderMaterial/fragment.glsl
+++ b/js/components/3D/Shaders/WaterShaderMaterial/fragment.glsl
@@ -114,7 +114,7 @@ float snoise(vec3 v) {
 
 vec3 perlin() {
     vec2 scale = vec2(1.0, uPerlinYScale);
-    vec2 position = vUv * (uPerlinResolution * scale);
+    vec2 position = vScreenSpace * (uPerlinResolution * scale);
     vec3 color = vec3(1.0);
     vec3 c = vec3(0.0);
 

--- a/js/components/HomeScene/Scene/Rig.jsx
+++ b/js/components/HomeScene/Scene/Rig.jsx
@@ -142,9 +142,9 @@ export default function Rig() {
                 cameraControls.minPolarAngle = cameraControls.polarAngle; // limit camera rotation to 90 degrees
                 cameraControls.maxPolarAngle = cameraControls.polarAngle;
                 cameraControls.minAzimuthAngle =
-                    cameraControls.azimuthAngle - 25 * THREE.MathUtils.DEG2RAD;
+                    cameraControls.azimuthAngle - 45 * THREE.MathUtils.DEG2RAD;
                 cameraControls.maxAzimuthAngle =
-                    cameraControls.azimuthAngle + 25 * THREE.MathUtils.DEG2RAD;
+                    cameraControls.azimuthAngle + 45 * THREE.MathUtils.DEG2RAD;
             };
 
             const handleControlEnd = () => {

--- a/js/components/HomeScene/Scene/Rig.jsx
+++ b/js/components/HomeScene/Scene/Rig.jsx
@@ -139,10 +139,20 @@ export default function Rig() {
             // if no box is selected, enable camera controls, resetting camera position when controls end
             const handleControlStart = (e) => {
                 cameraControls.saveState(); // save initial camera position
+                cameraControls.minPolarAngle = cameraControls.polarAngle; // limit camera rotation to 90 degrees
+                cameraControls.maxPolarAngle = cameraControls.polarAngle;
+                cameraControls.minAzimuthAngle =
+                    cameraControls.azimuthAngle - 25 * THREE.MathUtils.DEG2RAD;
+                cameraControls.maxAzimuthAngle =
+                    cameraControls.azimuthAngle + 25 * THREE.MathUtils.DEG2RAD;
             };
 
             const handleControlEnd = () => {
-                if (!cameraControls) return;
+                cameraControls.minPolarAngle = 0; // reset min/max polar angle to defaults
+                cameraControls.maxPolarAngle = Math.PI;
+                cameraControls.minAzimuthAngle = -Infinity; // reset min/max azimuth angle to defaults
+                cameraControls.maxAzimuthAngle = Infinity;
+
                 cameraControls.reset(true); // reset camera back to saved position
             };
 

--- a/js/lib/store/homeSceneSlice.js
+++ b/js/lib/store/homeSceneSlice.js
@@ -124,6 +124,9 @@ export const createHomeSceneSlice = (set, get) => ({
 
     lastOrbitDirection: "down",
     isOrbiting: false,
+    cameraControlsState: null,
+    setCameraControlsState: (cameraControlsState) =>
+        set(() => ({ cameraControlsState })),
 
     /**
      *
@@ -241,6 +244,7 @@ export const createHomeSceneSlice = (set, get) => ({
         set({
             isOrbiting: false,
             lastOrbitDirection: direction,
+            cameraControlsState: cameraControls.toJSON(),
         });
     },
     interactable: debug,


### PR DESCRIPTION
- Update camera controls to allow movement
- Setup camera control clamping
- Use screen space positioning for water
- Change water values to work better with screen space positioning
- Increase rotation limits to 45 degrees
- Setup camera controls saving of state
- Setup camera controls with prop events. Fix state saving bug
